### PR TITLE
Allow using a HTTP proxy for curl connections

### DIFF
--- a/src/main/QafooLabs/Profiler/CurlBackend.php
+++ b/src/main/QafooLabs/Profiler/CurlBackend.php
@@ -7,12 +7,18 @@ class CurlBackend implements Backend
     private $certificationFile;
     private $connectionTimeout;
     private $timeout;
+    private $proxy;
 
     public function __construct($certificationFile = null, $connectionTimeout = 3, $timeout = 3)
     {
         $this->certificationFile = $certificationFile;
         $this->connectionTimeout = $connectionTimeout;
         $this->timeout = $timeout;
+    }
+
+    public function setProxy($proxy)
+    {
+        $this->proxy = $proxy;
     }
 
     public function storeProfile(array $data)
@@ -75,6 +81,10 @@ class CurlBackend implements Backend
         } else {
             curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
             curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 0);
+        }
+
+        if ($this->proxy) {
+            curl_setopt($ch, CURLOPT_PROXY, $this->proxy);
         }
 
         $headers = array(

--- a/tests/QafooLabs/Profiler/CurlBackendTest.php
+++ b/tests/QafooLabs/Profiler/CurlBackendTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace QafooLabs\Profiler;
+
+class CurlBackendTest extends \PHPUnit_Framework_TestCase
+{
+    private $oldEnv = array();
+
+    protected function setUp()
+    {
+        $vars = array('http_proxy', 'https_proxy', 'no_proxy');
+        foreach ($vars as $currentVar) {
+            $this->oldEnv[$currentVar] = getenv($currentVar);
+            putenv($currentVar);
+        }
+    }
+
+    protected function tearDown()
+    {
+        foreach ($this->oldEnv as $var => $value) {
+            putenv("$var=$value");
+        }
+    }
+
+    public function testNoProxyEnvVars()
+    {
+        $curlBackend = new CurlBackend;
+        $this->assertNull($curlBackend->getProxy());
+    }
+
+    public function testHttpsProxy()
+    {
+        putenv('https_proxy=http://1.2.3.4:8443/');
+        putenv('http_proxy=http://1.2.3.4:8080/');
+        $curlBackend = new CurlBackend;
+        $this->assertSame('http://1.2.3.4:8443/', $curlBackend->getProxy());
+    }
+
+    public function testHttpProxyOnly()
+    {
+        putenv('http_proxy=http://1.2.3.4:8080/');
+        $curlBackend = new CurlBackend;
+        $this->assertSame('http://1.2.3.4:8080/', $curlBackend->getProxy());
+    }
+
+    public function testSkipProxyForHost()
+    {
+        putenv('https_proxy=http://1.2.3.4:8443/');
+        putenv('http_proxy=http://1.2.3.4:8080/');
+        putenv('no_proxy=localhost,127.0.0.1,profiler.qafoolabs.com,.example.com');
+        $curlBackend = new CurlBackend;
+        $this->assertNull($curlBackend->getProxy());
+    }
+
+    public function testSkipProxyForDomain()
+    {
+        putenv('https_proxy=http://1.2.3.4:8443/');
+        putenv('http_proxy=http://1.2.3.4:8080/');
+        putenv('no_proxy=localhost,127.0.0.1,.qafoolabs.com,.example.com');
+        $curlBackend = new CurlBackend;
+        $this->assertNull($curlBackend->getProxy());
+    }
+
+    public function testDoNotSkipProxy()
+    {
+        putenv('https_proxy=http://1.2.3.4:8443/');
+        putenv('http_proxy=http://1.2.3.4:8080/');
+        putenv('no_proxy=localhost,127.0.0.1,.example.com');
+        $curlBackend = new CurlBackend;
+        $this->assertSame('http://1.2.3.4:8443/', $curlBackend->getProxy());
+    }
+}


### PR DESCRIPTION
There's currently no way to use the `CurlBackend` class to connect to the profiler backend through a proxy. This small patch adds this functionality.

Example:

``` php
use QafooLabs\Profiler;

$backend = new Profiler\CurlBackend;
$backend->setProxy('http://1.2.3.4:8080/');
Profiler::setBackend($profilerBackend);
Profiler::start();
```

Or with an env variable:

``` php
$backend->setProxy(getenv('https_proxy'));
```
